### PR TITLE
Add support for GnuPG 2.1 ('modern') and MacPorts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,8 +54,8 @@ So, here's a script that performs the following tasks
 #### GnuPG
 The primary dependency is
 [GnuPG stable, v2.0.XX](https://www.gnupg.org/download/index.html).
-The software was developed using GnuPG-v2.0.22 but _might_ work with
-GnuPG-v2.1.xx modern. It will not work with GnuPG-v1.4.xx classic, though
+The software was developed using GnuPG-v2.0.22 and has been adapted to work
+with GnuPG-v2.1.26 modern. It will not work with GnuPG-v1.4.xx classic, though
 adding support for this version of GnuPG is certainly possible.
 
 ##### GNU/Linux
@@ -65,26 +65,44 @@ to install the required dependencies:
 sudo apt-get install gpgv2
 ```
 
-##### OSX
-On OSX, you can choose to install the
-[GPG Suite](https://gpgtools.org/gpgsuite.html) or use the Homebrew
-package for GnuPG v2:
+##### OS X / macOS
+On OS X / macOS, you can choose to install the
+[GPG Suite](https://gpgtools.org/gpgsuite.html - GnuPG v2 only at the present
+time) or use the Homebrew or MacPorts package for GnuPG v2 or v2.1:
+
+###### Homebrew
 ```bash
 brew install gnupg2
+```
+or
+```bash
+brew install gnupg21
 ```
 Additionally, you will also need to install `gnu-getopt`, 
 a command-line option parsing library.
 ```bash
 brew install gnu-getopt
 ```
-Since OSX already ships with `getopt(1)`, you will need to 
+Since OS X / macOS already ships with `getopt(1)`, you will need to 
 force-link this keg-only formula:
 ```bash
 brew link --force gnu-getopt
 ```
-You should unlink this formula after using the script to avoid trouble with OSX. 
+You should unlink this formula after using the script to avoid trouble with OS X / macOS. 
 ```bash
 brew unlink gnu-getopt
+```
+###### MacPorts
+```bash
+port install gnupg2
+```
+or
+```bash
+port install gnupg21
+```
+As for Homebrew, install the GNU getopt command-line parser:
+```bash
+port install getopt
 ```
 
 #### Enhancements
@@ -99,10 +117,16 @@ will enhance the output, if installed.
 sudo apt-get install qrencode paperkey
 ```
 
-##### OSX
+##### OS X / macOS
 
+###### Homebrew
 ```bash
 brew install qrencode paperkey
+```
+
+###### MacPorts
+```bash
+port install qrencode paperkey
 ```
 
 #### Note on Unix
@@ -110,7 +134,7 @@ This software was developed on Debian flavored GNU/Linux and uses
 [the Unix philosophy](https://en.wikipedia.org/wiki/Unix_philosophy)
 by combining the standard tools like
 `getopt`, `which`, `mktemp`, `grep`, `awk`, `mkdir`, `head`, and `shred`.
-Mileage may vary for users of Unix derived systems (like \*BSD and OSX).
+Mileage may vary for users of Unix derived systems (like \*BSD and OS X).
 Unix users may need to install
 [getopt(1)](http://linux.die.net/man/1/getopt)
 in order to use this software.
@@ -286,7 +310,7 @@ Small snippets and other inspiration were lifted from the
 [monkeysphere](http://web.monkeysphere.info/community/) code.
 
 Special thanks to [ruimarinho](https://github.com/ruimarinho) for adding 
-OSX functionality.
+OS X functionality.
 
 
 ## Contribute!


### PR DESCRIPTION
The main change in this commit is the addition of support for GnuPG 2.1 (_aka_ 'modern') while retaining the original behaviour with GnuPG 2.0 (_aka_ 'classic'). A minor change is support for running the script under MacPorts on OS X / macOS.

In comparison with v2.0, using v2.1:

- requires `--full-gen-key` rather than `--gen-key` to give access to the full key generation options;
- automatically generates a revocation certificate when generating a master key pair;
- includes keygrip information in key listings;
- simplifies the removal of a private key by turning it into a single file deletion operation (with the filename being based on the keygrip).

The script now parses the output of `gpg2 --version` to determine whether v2.0 or v2.1 is being used, sets the variable `EGK_GPGMODERN` to `false` or `true` and the variable `EGK_GPGGENKEY` to `--gen-key` or `--full-gen-key` respectively and uses the value of `EGK_GPGMODERN` to control the way various operations that differ between v2.0 and v2.1 are performed.

Keygrip information (which is present with v2.1 key listings) is parsed from the colon-delimited key listings and used in two ways:

- it's included in the YAML public key output; and
- used to identify the master private key file (if the master private key is to be removed).

Revocation certificate generation is skipped with v2.1 since one is automatically created along with the master key pair.

Securely deleting files accounts for MacPorts installing GNU `shred` as `gshred`.

The script has been tested with GnuPG 2.0.26 on Debian 8.6, GnuPG 2.1.16 on Raspbian 'testing' and GnuPG 2.1.16 (provided by MacPorts) on macOS 10.12.1.